### PR TITLE
Fix query in resource_list.kql

### DIFF
--- a/resource_list.kql
+++ b/resource_list.kql
@@ -94,7 +94,7 @@ type contains "microsoft.web/sites" and tostring(properties.siteProperties.prope
         tostring(properties.siteProperties.properties) contains "NODE|18-lts", 531,
 		-9999)
 ,-9999)
-| where ServiceID >0
+| where toint(ServiceID) >0
 | project ServiceID , subscriptionId, type, resourceGroup, location, id, tags = tostring(tags)
 | union
 ( resources


### PR DESCRIPTION
The filter ServiceID >0 is causing the following error at least from the Power BI Azure Resource Graph connector:

"We cannot apply field access to the type Null."

By converting the ServiceID value to integer using toint() fixed the issue.